### PR TITLE
Fix javadoc for jdbc-pool ConnectionPool.suspect()

### DIFF
--- a/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java
+++ b/modules/jdbc-pool/src/main/java/org/apache/tomcat/jdbc/pool/ConnectionPool.java
@@ -552,9 +552,9 @@ public class ConnectionPool {
     }
 
     /**
-     * thread safe way to abandon a connection
-     * signals a connection to be abandoned.
-     * this will disconnect the connection, and log the stack trace if logAbanded=true
+     * thread safe way to suspect a connection.
+     * similar to {@link #abandon(PooledConnection)}, but instead of actually abandoning the connection,
+     * this will log a warning and set the suspect flag on the {@link PooledConnection} if logAbandoned=true
      * @param con PooledConnection
      */
     protected void suspect(PooledConnection con) {


### PR DESCRIPTION
The javadoc for jdbc-pool ConnectionPool.suspect(PooledConnection) seemed to have been a copy-paste from ConnectionPool.abandon(PooledConnection).
