### PR TITLE
refactor compression method selection logic into separate class

### DIFF
--- a/java/org/apache/coyote/http11/AbstractHttp11Processor.java
+++ b/java/org/apache/coyote/http11/AbstractHttp11Processor.java
@@ -16,33 +16,11 @@
  */
 package org.apache.coyote.http11;
 
-import java.io.IOException;
-import java.io.InterruptedIOException;
-import java.nio.ByteBuffer;
-import java.util.Locale;
-import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.Pattern;
-
-import javax.servlet.RequestDispatcher;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.coyote.AbstractProcessor;
-import org.apache.coyote.ActionCode;
-import org.apache.coyote.AsyncContextCallback;
-import org.apache.coyote.ErrorState;
-import org.apache.coyote.RequestInfo;
-import org.apache.coyote.UpgradeToken;
-import org.apache.coyote.http11.filters.BufferedInputFilter;
-import org.apache.coyote.http11.filters.ChunkedInputFilter;
-import org.apache.coyote.http11.filters.ChunkedOutputFilter;
-import org.apache.coyote.http11.filters.GzipOutputFilter;
-import org.apache.coyote.http11.filters.IdentityInputFilter;
-import org.apache.coyote.http11.filters.IdentityOutputFilter;
-import org.apache.coyote.http11.filters.SavedRequestInputFilter;
-import org.apache.coyote.http11.filters.VoidInputFilter;
-import org.apache.coyote.http11.filters.VoidOutputFilter;
+import org.apache.coyote.*;
+import org.apache.coyote.http11.compression.CompressionLevel;
+import org.apache.coyote.http11.compression.CompressionMethod;
+import org.apache.coyote.http11.compression.CompressionMethodSelector;
+import org.apache.coyote.http11.filters.*;
 import org.apache.tomcat.util.ExceptionUtils;
 import org.apache.tomcat.util.buf.Ascii;
 import org.apache.tomcat.util.buf.ByteChunk;
@@ -57,6 +35,22 @@ import org.apache.tomcat.util.net.DispatchType;
 import org.apache.tomcat.util.net.SocketStatus;
 import org.apache.tomcat.util.net.SocketWrapper;
 import org.apache.tomcat.util.res.StringManager;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.nio.ByteBuffer;
+import java.util.Locale;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+import static org.apache.coyote.http11.compression.CompressionLevel.*;
+import static org.apache.coyote.http11.compression.CompressionMethod.GZIP;
+import static org.apache.coyote.http11.compression.CompressionMethod.NONE;
+import static org.apache.coyote.http11.compression.CompressionMethodSelector.GZIP_CONTENT_ENCODING;
 
 public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
 
@@ -188,7 +182,7 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
     /**
      * Allowed compression level.
      */
-    protected int compressionLevel = 0;
+    protected CompressionLevel compressionLevel = OFF;
 
 
     /**
@@ -203,10 +197,7 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
     protected int maxSavePostSize = 4 * 1024;
 
 
-    /**
-     * Regular expression that defines the user agents to not use gzip with
-     */
-    protected Pattern noCompressionUserAgents = null;
+    private CompressionMethodSelector compressionMethodSelector = new CompressionMethodSelector();
 
     /**
      * List of MIMES which could be gzipped
@@ -244,20 +235,15 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
      * Set compression level.
      */
     public void setCompression(String compression) {
-        if (compression.equals("on")) {
-            this.compressionLevel = 1;
-        } else if (compression.equals("force")) {
-            this.compressionLevel = 2;
-        } else if (compression.equals("off")) {
-            this.compressionLevel = 0;
-        } else {
+        compressionLevel = CompressionLevel.fromStringOrNull(compression);
+        if (compressionLevel == null) {
             try {
                 // Try to parse compression as an int, which would give the
                 // minimum compression size
                 compressionMinSize = Integer.parseInt(compression);
-                this.compressionLevel = 1;
-            } catch (Exception e) {
-                this.compressionLevel = 0;
+                this.compressionLevel = ON;
+            } catch (NumberFormatException e) {
+                this.compressionLevel = OFF;
             }
         }
     }
@@ -277,12 +263,7 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
      * ie: "gorilla|desesplorer|tigrus"
      */
     public void setNoCompressionUserAgents(String noCompressionUserAgents) {
-        if (noCompressionUserAgents == null || noCompressionUserAgents.length() == 0) {
-            this.noCompressionUserAgents = null;
-        } else {
-            this.noCompressionUserAgents =
-                Pattern.compile(noCompressionUserAgents);
-        }
+        compressionMethodSelector.setNoCompressionUserAgents(noCompressionUserAgents);
     }
 
     /**
@@ -330,15 +311,7 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
      * Return compression level.
      */
     public String getCompression() {
-        switch (compressionLevel) {
-        case 0:
-            return "off";
-        case 1:
-            return "on";
-        case 2:
-            return "force";
-        }
-        return "off";
+        return compressionLevel.asString();
     }
 
 
@@ -521,12 +494,12 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
             response.getMimeHeaders().getValue("Content-Encoding");
 
         if ((contentEncodingMB != null)
-            && (contentEncodingMB.indexOf("gzip") != -1)) {
+            && (contentEncodingMB.indexOf(GZIP_CONTENT_ENCODING) != -1)) {
             return false;
         }
 
         // If force mode, always compress (test purposes only)
-        if (compressionLevel == 2) {
+        if (compressionLevel == FORCE) {
             return true;
         }
 
@@ -542,43 +515,6 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
         }
 
         return false;
-    }
-
-
-    /**
-     * Check if compression should be used for this resource. Already checked
-     * that the resource could be compressed if the client supports it.
-     */
-    private boolean useCompression() {
-
-        // Check if browser support gzip encoding
-        MessageBytes acceptEncodingMB =
-            request.getMimeHeaders().getValue("accept-encoding");
-
-        if ((acceptEncodingMB == null)
-            || (acceptEncodingMB.indexOf("gzip") == -1)) {
-            return false;
-        }
-
-        // If force mode, always compress (test purposes only)
-        if (compressionLevel == 2) {
-            return true;
-        }
-
-        // Check for incompatible Browser
-        if (noCompressionUserAgents != null) {
-            MessageBytes userAgentValueMB =
-                request.getMimeHeaders().getValue("user-agent");
-            if(userAgentValueMB != null) {
-                String userAgentValue = userAgentValueMB.toString();
-
-                if (noCompressionUserAgents.matcher(userAgentValue).matches()) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
     }
 
 
@@ -1426,7 +1362,7 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
         if (http09 == true) {
             // HTTP/0.9
             getOutputBuffer().addActiveFilter
-                (outputFilters[Constants.IDENTITY_FILTER]);
+                    (outputFilters[Constants.IDENTITY_FILTER]);
             return;
         }
 
@@ -1435,7 +1371,7 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
                 statusCode == 304) {
             // No entity body
             getOutputBuffer().addActiveFilter
-                (outputFilters[Constants.VOID_FILTER]);
+                    (outputFilters[Constants.VOID_FILTER]);
             entityBody = false;
             contentDelimitation = true;
         }
@@ -1444,7 +1380,7 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
         if (methodMB.equals("HEAD")) {
             // No entity body
             getOutputBuffer().addActiveFilter
-                (outputFilters[Constants.VOID_FILTER]);
+                    (outputFilters[Constants.VOID_FILTER]);
             contentDelimitation = true;
         }
 
@@ -1456,14 +1392,14 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
 
         // Check for compression
         boolean isCompressable = false;
-        boolean useCompression = false;
-        if (entityBody && (compressionLevel > 0) && !sendingWithSendfile) {
+        CompressionMethod compressionMethod = NONE;
+        if (entityBody && (compressionLevel == ON || compressionLevel == FORCE) && !sendingWithSendfile) {
             isCompressable = isCompressable();
             if (isCompressable) {
-                useCompression = useCompression();
+                compressionMethod = compressionMethodSelector.getCompressionMethod(request, compressionLevel);
             }
             // Change content-length to -1 to force chunking
-            if (useCompression) {
+            if (compressionMethod != NONE) {
                 response.setContentLength(-1);
             }
         }
@@ -1481,7 +1417,7 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
             String contentLanguage = response.getContentLanguage();
             if (contentLanguage != null) {
                 headers.setValue("Content-Language")
-                    .setString(contentLanguage);
+                        .setString(contentLanguage);
             }
         }
 
@@ -1490,7 +1426,7 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
         if (contentLength != -1) {
             headers.setValue("Content-Length").setLong(contentLength);
             getOutputBuffer().addActiveFilter
-                (outputFilters[Constants.IDENTITY_FILTER]);
+                    (outputFilters[Constants.IDENTITY_FILTER]);
             contentDelimitation = true;
         } else {
             // If the response code supports an entity body and we're on
@@ -1498,18 +1434,18 @@ public abstract class AbstractHttp11Processor<S> extends AbstractProcessor<S> {
             connectionClosePresent = isConnectionClose(headers);
             if (entityBody && http11 && !connectionClosePresent) {
                 getOutputBuffer().addActiveFilter
-                    (outputFilters[Constants.CHUNKED_FILTER]);
+                        (outputFilters[Constants.CHUNKED_FILTER]);
                 contentDelimitation = true;
                 headers.addValue(Constants.TRANSFERENCODING).setString(Constants.CHUNKED);
             } else {
                 getOutputBuffer().addActiveFilter
-                    (outputFilters[Constants.IDENTITY_FILTER]);
+                        (outputFilters[Constants.IDENTITY_FILTER]);
             }
         }
 
-        if (useCompression) {
+        if (compressionMethod == GZIP) {
             getOutputBuffer().addActiveFilter(outputFilters[Constants.GZIP_FILTER]);
-            headers.setValue("Content-Encoding").setString("gzip");
+            headers.setValue("Content-Encoding").setString(GZIP_CONTENT_ENCODING);
         }
         // If it might be compressed, set the Vary header
         if (isCompressable) {

--- a/java/org/apache/coyote/http11/compression/CompressionLevel.java
+++ b/java/org/apache/coyote/http11/compression/CompressionLevel.java
@@ -1,0 +1,56 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.coyote.http11.compression;
+
+import org.apache.catalina.tribes.util.Arrays;
+
+public enum CompressionLevel {
+    OFF(0, 0),
+    ON(1, 5),
+    FORCE(2, 11);
+
+    public int gzipLevel;
+    public int brotliQuality;
+
+    CompressionLevel(int gzipLevel, int brotliQuality) {
+        this.gzipLevel = gzipLevel;
+        this.brotliQuality = brotliQuality;
+    }
+
+    public String asString() {
+        switch (this) {
+            case ON:
+                return "on";
+            case FORCE:
+                return "force";
+            default:
+                return "off";
+        }
+    }
+
+    public static CompressionLevel fromStringOrNull(String name) {
+        if ("on".equalsIgnoreCase(name)) {
+            return ON;
+        } else if ("force".equalsIgnoreCase(name)) {
+            return FORCE;
+        } else if ("off".equalsIgnoreCase(name)) {
+            return OFF;
+        }
+        throw new IllegalArgumentException("Invalid compression level '" + name + "'. Allowed values: " + Arrays.toString(CompressionLevel.values()));
+    }
+}

--- a/java/org/apache/coyote/http11/compression/CompressionMethod.java
+++ b/java/org/apache/coyote/http11/compression/CompressionMethod.java
@@ -1,0 +1,23 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.coyote.http11.compression;
+
+public enum CompressionMethod {
+    NONE,
+    GZIP
+}

--- a/java/org/apache/coyote/http11/compression/CompressionMethodSelector.java
+++ b/java/org/apache/coyote/http11/compression/CompressionMethodSelector.java
@@ -1,0 +1,99 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.coyote.http11.compression;
+
+import org.apache.coyote.Request;
+import org.apache.tomcat.util.buf.MessageBytes;
+
+import java.util.regex.Pattern;
+
+import static org.apache.coyote.http11.compression.CompressionLevel.FORCE;
+import static org.apache.coyote.http11.compression.CompressionMethod.GZIP;
+import static org.apache.coyote.http11.compression.CompressionMethod.NONE;
+
+public class CompressionMethodSelector {
+
+    public static final String GZIP_CONTENT_ENCODING = "gzip";
+
+    /**
+     * Regular expression that defines the user agents to not use gzip with
+     */
+    protected Pattern noCompressionUserAgents = null;
+
+    public CompressionMethod getCompressionMethod(Request request,
+                                                  CompressionLevel compressionLevel) {
+        if (useCompression(request, compressionLevel, GZIP_CONTENT_ENCODING)) return GZIP;
+        return NONE;
+    }
+
+    /**
+     * Check if compression should be used for this resource. Already checked
+     * that the resource could be compressed if the client supports it.
+     * @param request           request
+     * @param compressionLevel  compressionLevel
+     * @param acceptHeaderValue acceptHeaderValue
+     */
+    private boolean useCompression(Request request, CompressionLevel compressionLevel,
+                                   String acceptHeaderValue) {
+
+        // Check if browser support gzip encoding
+        MessageBytes acceptEncodingMB =
+                request.getMimeHeaders().getValue("Accept-Encoding");
+
+        if ((acceptEncodingMB == null)
+                || (acceptEncodingMB.indexOf(acceptHeaderValue) == -1)) {
+            return false;
+        }
+
+        // If force mode, always compress (test purposes only)
+        if (compressionLevel == FORCE) {
+            return true;
+        }
+
+        // Check for incompatible Browser
+        if (noCompressionUserAgents != null) {
+            MessageBytes userAgentValueMB =
+                    request.getMimeHeaders().getValue("User-Agent");
+            if(userAgentValueMB != null) {
+                String userAgentValue = userAgentValueMB.toString();
+
+                if (userAgentValue != null &&
+                        noCompressionUserAgents.matcher(userAgentValue).matches()) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Set no compression user agent pattern. Regular expression as supported
+     * by {@link Pattern}.
+     *
+     * ie: "gorilla|desesplorer|tigrus"
+     */
+    public void setNoCompressionUserAgents(String noCompressionUserAgents) {
+        if (noCompressionUserAgents == null || noCompressionUserAgents.length() == 0) {
+            this.noCompressionUserAgents = null;
+        } else {
+            this.noCompressionUserAgents =
+                    Pattern.compile(noCompressionUserAgents);
+        }
+    }
+}

--- a/java/org/apache/coyote/http11/compression/CompressionMethodSelector.java
+++ b/java/org/apache/coyote/http11/compression/CompressionMethodSelector.java
@@ -33,7 +33,7 @@ public class CompressionMethodSelector {
     /**
      * Regular expression that defines the user agents to not use gzip with
      */
-    protected Pattern noCompressionUserAgents = null;
+    private Pattern noCompressionUserAgents = null;
 
     public CompressionMethod getCompressionMethod(Request request,
                                                   CompressionLevel compressionLevel) {

--- a/test/org/apache/coyote/http11/compression/TestCompressionMethodSelector.java
+++ b/test/org/apache/coyote/http11/compression/TestCompressionMethodSelector.java
@@ -1,0 +1,77 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.coyote.http11.compression;
+
+import org.apache.coyote.Request;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestCompressionMethodSelector {
+
+    private CompressionMethodSelector compressionMethodSelector;
+    private Request request;
+
+    @Before
+    public void setUp() throws Exception {
+        compressionMethodSelector = new CompressionMethodSelector();
+        request = new Request();
+    }
+
+    @Test
+    public void testWhenAcceptEncodingIsMissing()
+            throws Exception {
+
+        CompressionMethod method;
+
+        method = compressionMethodSelector
+                .getCompressionMethod(request, CompressionLevel.ON);
+        assertEquals(CompressionMethod.NONE, method);
+
+        method = compressionMethodSelector
+                .getCompressionMethod(request, CompressionLevel.FORCE);
+        assertEquals(CompressionMethod.NONE, method);
+
+        method = compressionMethodSelector
+                .getCompressionMethod(request, CompressionLevel.OFF);
+        assertEquals(CompressionMethod.NONE, method);
+    }
+
+    @Test
+    public void testWhenAcceptEncodingHasValueGZIP()
+            throws Exception {
+
+        CompressionMethod method;
+        request.getMimeHeaders()
+                .addValue("Accept-Encoding")
+                .setString(CompressionMethodSelector.GZIP_CONTENT_ENCODING);
+
+        method = compressionMethodSelector
+                .getCompressionMethod(request, CompressionLevel.ON);
+        assertEquals(CompressionMethod.GZIP, method);
+
+        method = compressionMethodSelector
+                .getCompressionMethod(request, CompressionLevel.FORCE);
+        assertEquals(CompressionMethod.GZIP, method);
+
+        method = compressionMethodSelector
+                .getCompressionMethod(request, CompressionLevel.OFF);
+        assertEquals(CompressionMethod.GZIP, method);
+    }
+}


### PR DESCRIPTION
Hi,

this PR doesn't add any new feature, but just refactors compression selection logic
into separate class. This is just because of single responsibility concept
and increases readability.

Every feedback is welcome.

Regards
Martin
