### PR TITLE
Fix https://bz.apache.org/bugzilla/show_bug.cgi?id=59226

### DIFF
--- a/java/org/apache/tomcat/util/scan/StandardJarScanner.java
+++ b/java/org/apache/tomcat/util/scan/StandardJarScanner.java
@@ -23,8 +23,10 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.servlet.ServletContext;
@@ -123,6 +125,69 @@ public class StandardJarScanner implements JarScanner {
     }
 
     /**
+     * Returns the search path of URLs for loading classes and resources for the 
+     * specified class loader, including those referenced in the 
+     * {@code Class-path} header of the manifest of a executable jar, in the 
+     * case of class loader being the system class loader. 
+     * <p>
+     * Note: These last jars are not returned by 
+     * {@link java.net.URLClassLoader#getURLs()}.
+     * </p>
+     * @param cl
+     * @return 
+     */
+    public static URL[] getURLs(URLClassLoader cl) {
+        if (cl.getParent() == null || !(cl.getParent() 
+                instanceof URLClassLoader)) {
+            return cl.getURLs();
+        }
+        Set<URL> urlSet = new LinkedHashSet();
+        URL[] urLs = cl.getURLs();
+        URL[] urlsFromManifest = getJarUrlsFromManifests(cl);
+        URLClassLoader parentCl = (URLClassLoader) cl.getParent();
+        URL[] ancestorUrls = getJarUrlsFromManifests(parentCl);
+        
+        for (int i = 0; i < urlsFromManifest.length; i++) {
+            urlSet.add(urlsFromManifest[i]);
+        }
+        for (int i = 0; i < ancestorUrls.length; i++) {
+            urlSet.remove(ancestorUrls[i]);
+        }
+        for (int i = 0; i < urLs.length; i++) {
+            urlSet.add(urLs[i]);
+        }
+        return urlSet.toArray(new URL[urlSet.size()]);
+    }
+    
+    /**
+     * Returns the URLs of those jar managed by this classloader (or its 
+     * ascendant classloaders) that have a manifest
+     * @param cl
+     * @return 
+     */
+    private static URL[] getJarUrlsFromManifests(ClassLoader cl) {
+        try {
+            Set<URL> urlSet = new LinkedHashSet();
+            Enumeration<URL> manifestUrls = 
+                    cl.getResources("META-INF/MANIFEST.MF");
+            while (manifestUrls.hasMoreElements()) {
+                try {
+                    URL manifestUrl = manifestUrls.nextElement();
+                    if(manifestUrl.getProtocol().equals("jar")) {
+                        urlSet.add(new URL(manifestUrl.getFile().substring(0, 
+                                manifestUrl.getFile().lastIndexOf("!"))));
+                    }
+                } catch (MalformedURLException ex) {
+                    throw new AssertionError();
+                }
+            }
+            return urlSet.toArray(new URL[urlSet.size()]);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    
+    /**
      * Scan the provided ServletContext and class loader for JAR files. Each JAR
      * file found will be passed to the callback handler to be processed.
      *
@@ -219,7 +284,7 @@ public class StandardJarScanner implements JarScanner {
                     if (isWebapp) {
                         isWebapp = isWebappClassLoader(classLoader);
                     }
-                    URL[] urls = ((URLClassLoader) classLoader).getURLs();
+                    URL[] urls = getURLs((URLClassLoader) classLoader);
                     for (int i=0; i<urls.length; i++) {
                         if (processedURLs.contains(urls[i])) {
                             // Skip this URL it has already been processed

--- a/java/org/apache/tomcat/util/scan/StandardJarScanner.java
+++ b/java/org/apache/tomcat/util/scan/StandardJarScanner.java
@@ -137,15 +137,15 @@ public class StandardJarScanner implements JarScanner {
      * @return 
      */
     public static URL[] getURLs(URLClassLoader cl) {
-        if (cl.getParent() == null || !(cl.getParent() 
+        if (cl != ClassLoader.getSystemClassLoader() || cl.getParent() == null || !(cl.getParent() 
                 instanceof URLClassLoader)) {
             return cl.getURLs();
         }
         Set<URL> urlSet = new LinkedHashSet();
         URL[] urLs = cl.getURLs();
-        URL[] urlsFromManifest = getJarUrlsFromManifests(cl);
+        URL[] urlsFromManifest = getJarUrlsFromVisibleManifests(cl);
         URLClassLoader parentCl = (URLClassLoader) cl.getParent();
-        URL[] ancestorUrls = getJarUrlsFromManifests(parentCl);
+        URL[] ancestorUrls = getJarUrlsFromVisibleManifests(parentCl);
         
         for (int i = 0; i < urlsFromManifest.length; i++) {
             urlSet.add(urlsFromManifest[i]);
@@ -165,7 +165,7 @@ public class StandardJarScanner implements JarScanner {
      * @param cl
      * @return 
      */
-    private static URL[] getJarUrlsFromManifests(ClassLoader cl) {
+    private static URL[] getJarUrlsFromVisibleManifests(ClassLoader cl) {
         try {
             Set<URL> urlSet = new LinkedHashSet();
             Enumeration<URL> manifestUrls = 


### PR DESCRIPTION
StandardJarScanner ignores jars in manifest Class-path header.

https://bz.apache.org/bugzilla/show_bug.cgi?id=59226

http://stackoverflow.com/questions/35922072/scanning-manifest-classpath-jars-in-embeeded-tomcat/36185408#36185408
