### PR TITLE
Correct comments about Java 8 in Jre8Compat

### DIFF
--- a/java/org/apache/tomcat/util/compat/Jre8Compat.java
+++ b/java/org/apache/tomcat/util/compat/Jre8Compat.java
@@ -35,9 +35,10 @@ class Jre8Compat extends JreCompat {
         Method m2 = null;
         Method m3 = null;
         try {
-            // Get this class first since it is Java 8+ only
+            // The class is Java6+...
             Class<?> c2 = Class.forName("javax.net.ssl.SSLParameters");
             m1 = SSLServerSocket.class.getMethod("getSSLParameters");
+            // ...but this method is Java8+
             m2 = c2.getMethod("setUseCipherSuitesOrder", boolean.class);
             m3 = SSLServerSocket.class.getMethod("setSSLParameters", c2);
         } catch (SecurityException e) {


### PR DESCRIPTION
Following from https://github.com/apache/tomcat70/pull/12:

`javax.net.ssl.SSLParameters` exists since Java 6, but the method `setUseCipherSuitesOrder` exists since Java 8.

Make this clear in the comments.