### PR TITLE
Fix random SocketTimeoutExceptions when reading request InputStream

### DIFF
--- a/java/org/apache/tomcat/util/net/NioBlockingSelector.java
+++ b/java/org/apache/tomcat/util/net/NioBlockingSelector.java
@@ -149,7 +149,7 @@ public class NioBlockingSelector {
      * take up a lot of CPU cycles.
      * @param buf ByteBuffer - the buffer containing the data, we will read as until we have read at least one byte or we timed out
      * @param socket SocketChannel - the socket to write data to
-     * @param readTimeout long - the timeout for this read operation in milliseconds, -1 means no timeout
+     * @param readTimeout long - the timeout for this read operation in milliseconds, 0 means no timeout
      * @return int - returns the number of bytes read
      * @throws EOFException if read returns -1
      * @throws SocketTimeoutException if the read times out
@@ -179,7 +179,7 @@ public class NioBlockingSelector {
                 try {
                     if ( att.getReadLatch()==null || att.getReadLatch().getCount()==0) att.startReadLatch(1);
                     poller.add(att,SelectionKey.OP_READ, reference);
-                    if (readTimeout < 0) {
+                    if (readTimeout <= 0) {
                         att.awaitReadLatch(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
                     } else {
                         att.awaitReadLatch(readTimeout, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
During performance testing of a web application it has been determined that under high load Tomcat can randomly throw a SocketTimeoutException when the application tries to read the request InputStream. Upon further investigation it has been found that the problem was somewhere within NioBlockingSelector, especially the code change introduced with https://github.com/apache/tomcat70/commit/ddc6068275513ac32be73b1767a1dee78ca27bd8 was of interest.

The gist of the issue:
* the read method's readTimeout parameter is documented to consider -1 as no socket timeout.
* InternalNioInputBuffer on the other hand passes in the value of Socket#getSoTimeout, which per JavaDoc:

> 0 returns implies that the option is disabled (i.e., timeout of infinity).

The end result is that for a socket that is not meant to have a read timeout specified, an immediate socket timeout is triggered upon reading (when that data wasn't available at the time of the read call).

Since the endless loop is still something that should be prevented, I've changed the surrounding code instead to indefinitely wait for new data.

Personally I'd consider this as a critical bug introduced with Tomcat 7.0.15 and still present in Tomcat 8.0.47-dev.

Once I patched my local Tomcat instance, the performance test was able to run successfully and I had no more random SocketTimeoutExceptions in the logs.